### PR TITLE
ノーツ情報に、対応GameObjectへの参照を追加

### DIFF
--- a/Assets/Scripts/Model/NotesManager/NoteData.cs
+++ b/Assets/Scripts/Model/NotesManager/NoteData.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using UnityEngine;
 
 ///	<summary>
 /// NoteEdiitorで生成された譜面構造を、クラス形式で定義するためのシリアライズ可能なクラス。
@@ -36,6 +37,19 @@ public class NoteData
         set
         {
             aActionRequiredTime = value;
+        }
+    }
+
+    private GameObject aNoteGameObject;
+    public GameObject NoteGameObject
+    {
+        get
+        {
+            return aNoteGameObject;
+        }
+        set
+        {
+            aNoteGameObject = value;
         }
     }
     public NoteData[] notes;

--- a/Assets/Scripts/Model/NotesManager/NotesManagerModel.cs
+++ b/Assets/Scripts/Model/NotesManager/NotesManagerModel.cs
@@ -17,7 +17,6 @@ public class NotesManagerModel : MonoBehaviour
             return aNoteList;
         }
     }
-    private List<GameObject> aNoteObjects = new List<GameObject>();
 
     private Dictionary<string, GameObject> aBaseNoteObjects;
 
@@ -60,11 +59,12 @@ public class NotesManagerModel : MonoBehaviour
             float aBeatSec = anInterval * aNote.LPB;
             float aTime = (aBeatSec * aNote.num / aNote.LPB) + aNotesInfomation.offset * 0.01f;
 
-            aNote.ActionRequiredTime = aTime;
-            this.aNoteList.Add(aNote);
-
             float aDistance = aTime * aNotesSpeed;
-            this.aNoteObjects.Add(Instantiate(this.aBaseNoteObjects[aNote.TypeName], new Vector3(aNote.block - 1.5f, 0.55f, aDistance), Quaternion.identity));
+            GameObject aNoteGameObject = Instantiate(this.aBaseNoteObjects[aNote.TypeName], new Vector3(aNote.block - 1.5f, 0.55f, aDistance), Quaternion.identity);
+
+            aNote.ActionRequiredTime = aTime;
+            aNote.NoteGameObject = aNoteGameObject;
+            this.aNoteList.Add(aNote);
         });
     }
 


### PR DESCRIPTION
## このPRには以下の変更が含まれています。
- ノーツ情報から、対応するGameObjectを参照できるように変更。
- ノーツマネージャーにて、ノーツに対応するゲームオブジェクトを生成する際、生成したGameObjectをノーツ情報から参照できるように、NoteGameObjectへのbindを行うように修正